### PR TITLE
Fix falsy args filtering

### DIFF
--- a/source/ast.generator.js
+++ b/source/ast.generator.js
@@ -126,7 +126,7 @@ function convertArray(arrayArgument, previousInstance = yup) {
 
     // Handle the case when we've got an array of empty elements
     if (convertedArguments instanceof Array) {
-        if (convertedArguments.filter(i => i).length < 1) {
+        if (convertedArguments.filter(i => i !== undefined).length < 1) {
             return gotFunc();
         }
 

--- a/source/tests/converter.test.js
+++ b/source/tests/converter.test.js
@@ -87,6 +87,15 @@ const numberTests = [
             failure: [1, 2, 3, 4, 501, 502, 503],
         },
     },
+    {
+        name: 'Converts simple type with falsy args',
+        input: [['yup.number'], ['yup.required'], ['yup.min', 0]],
+        validates: {
+            // prettier-no-wrap
+            success: [0, 50],
+            failure: [-50],
+        },
+    },
 ];
 
 const stringTests = [


### PR DESCRIPTION
Currently, this expression
https://github.com/WASD-Team/yup-ast/blob/80f91cab5e469762ebdfd4629a1a6d131ec293b3/source/ast.generator.js#L129
is filtering out falsy values like `0`, `''`, `null`, `false`, etc.

This means that:
```js
transformAll(
  [["yup.number"], ["yup.min", 0]]
).validateSync(42)
```

#### AR
Will fail with the message
```
ValidationError: this must be greater than or equal to undefined
```

#### ER
Will succeed, returning the `42` value.

#### Thoughts
I assume that it's supposed to skip only `undefined` values instead so I created this PR. Please correct me if I'm wrong. Thank you!

You can check that the new test with `0` fails if you remove the `!== undefined` part.